### PR TITLE
Amended xthreads in instcomp.g

### DIFF
--- a/src/hal/i-components/xthread.comp
+++ b/src/hal/i-components/xthread.comp
@@ -23,9 +23,6 @@ instanceparam string pinprefix = "compnew";
 option extra_inst_setup;
 option extra_inst_cleanup;
 
-    // Will create and export xthread funct in each component
-option xthreads;
-
 license "GPL";
 
 function _;

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-#    This is 'comp', a tool to write HAL boilerplateextra_setup
+#    This is 'comp', a tool to write HAL boilerplate
 #    Copyright 2006 Jeff Epler <jepler@unpythonic.net>
 #
 #    This program is free software; you can redistribute it and/or modify
@@ -118,7 +118,7 @@ mp_decl_map = {'int': 'RTAPI_MP_INT', 'dummy': None}
 # names.  That includes not only global variables and functions, but also
 # HAL pins & parameters, because comp adds #defines with the names of HAL
 # pins & params.
-reserved_names = [ 'comp_id', 'fperiod', 'rtapi_app_main', 'rtapi_app_exit', 'extra_inst_setup', 'extra_inst_cleanup', 'xthreads']
+reserved_names = [ 'comp_id', 'fperiod', 'rtapi_app_main', 'rtapi_app_exit', 'extra_inst_setup', 'extra_inst_cleanup']
 
 def _parse(rule, text, filename=None):
     global P, S
@@ -493,17 +493,16 @@ static int comp_id;
 
 ###################################  xthread_funct()  #######################################
 
-    if options.get("xthreads"):
-        print >>f, "static int xthread_funct(const void *arg, const hal_funct_args_t *fa)\n{"
-        print >>f, "long period __attribute__((unused)) = fa_period(fa);\n"
+    print >>f, "static int xthread_funct(const void *arg, const hal_funct_args_t *fa)\n{"
+    print >>f, "long period __attribute__((unused)) = fa_period(fa);\n"
     
-        print >>f, "    // the following accessors are available here:"
-        print >>f, "    // fa_period(fa) - formerly 'long period'"
-        print >>f, "    // fa_thread_start_time(fa): _actual_ start time of thread invocation"
-        print >>f, "    // fa_start_time(fa): _actual_ start time of function invocation"
-        print >>f, "    // fa_thread_name(fa): name of the calling thread (char *)"
-        print >>f, "    // fa_funct_name(fa): name of the this called function (char *)"
-        print >>f, "    return 0;\n}\n"
+    print >>f, "    // the following accessors are available here:"
+    print >>f, "    // fa_period(fa) - formerly 'long period'"
+    print >>f, "    // fa_thread_start_time(fa): _actual_ start time of thread invocation"
+    print >>f, "    // fa_start_time(fa): _actual_ start time of function invocation"
+    print >>f, "    // fa_thread_name(fa): name of the calling thread (char *)"
+    print >>f, "    // fa_funct_name(fa): name of the this called function (char *)"
+    print >>f, "    return 0;\n}\n"
 
 
 
@@ -640,20 +639,19 @@ static int comp_id;
     print >>f, "    if (comp_id < 0)"
     print >>f, "        return -1;\n"
 
-    if options.get("xthreads"):
-        print >>f, "    // exporting an extended thread function:"
-        print >>f, "    hal_export_xfunct_args_t xtf = "
-        print >>f, "        {"
-        print >>f, "        .type = FS_XTHREADFUNC,"
-        print >>f, "        .funct.x = xthread_funct,"
-        print >>f, "        .arg = \"x-instance-data\","
-        print >>f, "        .uses_fp = 0,"
-        print >>f, "        .reentrant = 0,"
-        print >>f, "        .owner_id = comp_id"
-        print >>f, "        };\n"
+    print >>f, "    // exporting an extended thread function:"
+    print >>f, "    hal_export_xfunct_args_t xtf = "
+    print >>f, "        {"
+    print >>f, "        .type = FS_XTHREADFUNC,"
+    print >>f, "        .funct.x = xthread_funct,"
+    print >>f, "        .arg = \"x-instance-data\","
+    print >>f, "        .uses_fp = 0,"
+    print >>f, "        .reentrant = 0,"
+    print >>f, "        .owner_id = comp_id"
+    print >>f, "        };\n"
     
-        print >>f, "    if (hal_export_xfunctf(&xtf,\"%s.xthread-funct\", compname))"
-        print >>f, "        return -1;"
+    print >>f, "    if (hal_export_xfunctf(&xtf,\"%s.xthread-funct\", compname))"
+    print >>f, "        return -1;"
 
     print >>f, "    hal_ready(comp_id);\n"
     


### PR DESCRIPTION
Make use of xthread default - example modified - option xthreads removed

Signed-off-by: Mick <arceye@mgware.co.uk>