### PR TITLE
Corrections and additions to instcomp.g

### DIFF
--- a/src/hal/i-components/bitslice_inst.comp
+++ b/src/hal/i-components/bitslice_inst.comp
@@ -1,0 +1,33 @@
+component bitslice_inst "";
+
+pin in u32 in           "The input value";
+pin out bit out-##[pincount];
+
+instanceparam int maxpincount = 32;
+
+    // This is the default number of pins for a component
+    // Can be varied <= maxpincount
+
+instanceparam int pincount = 16;
+
+// The default prefix for the new instantiation will be bitslice.<pin> etc
+// This param will change that name if used at newinst
+// eg.  halcmd newinst bitslice pinprefix=slice8 pincount=8
+
+instanceparam string pinprefix = "";
+
+
+author "Andy Pugh";
+license "GPL2+";
+function _ nofp;
+;;
+
+
+FUNCTION(_) 
+{
+int i;
+    for (i = 0; i < pincount ; i++)
+        out(i) = (in >> i)&1;
+
+}
+

--- a/src/hal/i-components/gantry_inst.comp
+++ b/src/hal/i-components/gantry_inst.comp
@@ -1,0 +1,175 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2014 Charles Steinkuehler (charles AT steinkuehler DOT net)
+ *
+ *
+ * This module allows multiple drive motors (joints) to be connected to a
+ * single motion axis.  This is useful for gantry style machines if you don't
+ * want to use gantrykins
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * THE AUTHORS OF THIS PROGRAM ACCEPT ABSOLUTELY NO LIABILITY FOR
+ * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE
+ * TO RELY ON SOFTWARE ALONE FOR SAFETY.  Any machinery capable of
+ * harming persons must have provisions for completely removing power
+ * from all motors, etc, before persons enter any danger area.  All
+ * machinery must be designed to comply with local and national safety
+ * codes, and the authors of this software can not, and do not, take
+ * any responsibility for such compliance.
+ *
+ * This code was written as part of the LinuxCNC project.  For more
+ * information, go to www.linuxcnc.org.
+ *
+ ******************************************************************************/
+
+component gantry_inst "Machinekit HAL component for driving multiple joints from a single axis";
+pin out float joint.##.pos-cmd [pincount] "Per-joint commanded position";
+pin in  float joint.##.pos-fb  [pincount] "Per-joint position feedback";
+pin in  bit   joint.##.home    [pincount] "Per-joint home switch";
+pin out float joint.##.offset  [pincount] "(debugging) Per-joint offset value, updated when homing";
+pin in  float position-cmd "Commanded position from motion";
+pin out float position-fb "Position feedback to motion";
+pin out bit   home "Combined home signal, true if all joint home inputs are true";
+pin out bit   limit "Combined limit signal, true if any joint home input is true";
+pin in  float search-vel "HOME_SEARCH_VEL from ini file";
+function read  fp "Update position-fb and home/limit outputs based on joint values";
+function write fp "Update joint pos-cmd outputs based on position-cmd in";
+
+instanceparam int maxpincount = 7;
+
+    // This is the default number of pins for a component
+    // Can be varied <= maxpincount
+
+instanceparam int pincount = 7;
+
+// The default prefix for the new instantiation will be bitslice.<pin> etc
+// This param will change that name if used at newinst
+// eg.  halcmd newinst bitslice pinprefix=slice8 pincount=8
+
+instanceparam string pinprefix = "gantry7";
+
+description """
+Drives multiple physical motors (joints) from a single axis input
+.LP
+The `pincount' value is the number of joints to control.  Two is typical, but
+up to seven is supported (a three joint setup has been tested with hardware).
+.LP
+All controlled joints track the commanded position (with a per-joint offset)
+unless in the process of homing.  Homing is when the commanded position is
+moving towards the homing switches (as determined by the sign of search-vel)
+and the joint home switches are not all in the same state.  When the system is
+homing and a joint home switch activates, the command value sent to that joint
+is "frozen" and the joint offset value is updated instead.  Once all home
+switches are active, there are no more adjustments made to the offset values
+and all joints run in lock-step once more.
+.LP
+For best results, set HOME_SEARCH_VEL and HOME_LATCH_VEL to the same direction
+and as slow as practical.  When a joint home switch trips, the commanded
+velocity will drop immediately from HOME_SEARCH_VEL to zero, with no limit on
+accleration.
+""";
+license "GPL";
+variable float offset[7] = 0.0;
+variable float prev_cmd = 0.0;
+variable int   fb_joint = 0;
+variable int   latching = 0;
+;;
+FUNCTION(read) {
+    int i=1;
+
+    // First (or only) joint
+    home=joint_home(0);
+    limit=joint_home(0);
+
+    // All other joints, if configured
+    while (i < pincount) {
+        // Check to see if machine is in latching state
+        if(latching==0)
+        {
+            // Don't asset home until all joints hit their home switches
+            home  &= joint_home(i);
+        }
+        else
+        {
+            // Don't release home until all joints have backed off their
+            // home switches
+            home |= joint_home(i);
+        }
+
+        // Remember the home state for next time
+        latching=home;
+
+        // Limit is always asserted if any home switch is asserted
+        limit |= joint_home(i);
+        i++;
+    }
+
+    // Joint used for feedback is 'sticky', but we have to switch to
+    // track active joints or motion gets upset with the sudden
+    // stop.  If all joints are not homed, but the current joint used
+    // for feedback is, find a joint that's still active
+    if ((joint_home(fb_joint) == 1) && (home == 0)) {
+        for (i=0; i < pincount; i++) {
+            if (joint_home(i) == 0) {
+                position_fb = joint_pos_fb(i) + offset[i];
+                fb_joint = i;
+                break;
+            }
+        }
+    } else {
+        position_fb = joint_pos_fb(fb_joint) + offset[fb_joint];
+    }
+}
+
+FUNCTION(write) {
+    int i;
+    float delta;
+
+    // Determine if we're moving in the same direction as home search
+
+    // First calculate the direction we're moving now
+    delta = position_cmd - prev_cmd;
+
+    // Stash current commanded position for next time
+    prev_cmd = position_cmd;
+
+    // Then multiply our delta value by the search velocity
+    // If the signs match and neither is zero, the result will be positive
+    // indicate we are moving towards home.  Otherwise, the result will be
+    // zero or negative.
+    //
+    // If we're moving towards home and all home switches are not closed
+    if ( ((delta * search_vel) > 0) && (home==0) ) {
+        // Check each joint to see if it's home switch is active
+        for (i=0; i < pincount; i++) {
+            // If home switch is active, update offset, not pos_cmd
+            // so the other joints can catch up
+            if (joint_home(i)==1) {
+                offset[i] += delta;
+            }
+        }
+    }
+
+    // Update each joint's commanded position
+    for (i=0; i < pincount; i++) {
+        joint_pos_cmd(i) = position_cmd - offset[i];
+        joint_offset(i)  = offset[i];
+    }
+}
+

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -509,8 +509,7 @@ static int comp_id;
 ###########################  export_halobjs()  ######################################################
 
     print >>f, "static int export_halobjs(struct inst_data *ip, int owner_id, const char *name)\n{"
-    if len(functions) > 1:
-        print >>f, "    char buf[HAL_NAME_LEN + 1];"
+    print >>f, "    char buf[HAL_NAME_LEN + 1];"
     print >>f, "    int r = 0;"
     if has_array:
         print >>f, "    int j = 0;"
@@ -565,11 +564,29 @@ static int comp_id;
         else:
             print >>f, "    ip->%s = %s;" % (name, value)
 
+    print >>f, "    // exporting an extended thread function:"
+    print >>f, "    hal_export_xfunct_args_t instxf = "
+    print >>f, "        {"
+    print >>f, "        .type = FS_XTHREADFUNC,"
+    print >>f, "        .funct.x = xthread_funct,"
+    print >>f, "        .arg = \"x-instance-data\","
+    print >>f, "        .uses_fp = 0,"
+    print >>f, "        .reentrant = 0,"
+    print >>f, "        .owner_id = owner_id"
+    print >>f, "        };\n"
+    
     for name, fp in functions:
-        strg = "    r = hal_export_functf(%s, ip, 0, 0, owner_id," % (to_c(name))
-        strg +=  "\"%s.funct\", name);"
-        print >>f, strg
-        print >>f, "    if(r != 0) return r;"
+        print >>f, "    instxf.uses_fp = %d;" % int(fp)
+        strng =  "    rtapi_snprintf(buf, sizeof(buf),\"%s."
+        if (name == "" or name == "_" or name == " ") :
+            strng += "xthread-funct\", name);"
+        else :
+            strng += "%s.xthread-funct\", name);" % (to_hal(name))
+        print >>f, strng 
+          
+        print >>f, "    r = hal_export_xfunctf(&instxf, buf, name);"
+       
+        print >>f, "    if(r != 0)\n        return r;"
 
     print >>f, "    return 0;"
     print >>f, "}"


### PR DESCRIPTION
Now creates xfunctf threads for instances as well as base component

Handles multiple functions, creating threads with fp flag set as req.

Examples from reworked existing components demonstrate:
bitslice_inst.comp - replacement of personality syntax with a per instance
pincount, maxpincount and pinprefix instanceparams

gantry_inst.comp - catering for more than one named function declared as
function <name> fp;
in the comp file, with unique thread names for each

Signed-off-by: Mick <arceye@mgware.co.uk>