### PR TITLE
Fixed param pointer indirection bug in instcomp.g

### DIFF
--- a/src/hal/i-components/arraytest.comp
+++ b/src/hal/i-components/arraytest.comp
@@ -7,7 +7,7 @@ param rw s32 iter;
 
 instanceparam int maxpincount = 32;
 instanceparam int pincount = 8;
-instanceparam string pinprefix = "compnew";
+instanceparam string iprefix = "compnew";
 
 option extra_inst_setup;
 option extra_inst_cleanup;

--- a/src/hal/i-components/bitslice_inst.comp
+++ b/src/hal/i-components/bitslice_inst.comp
@@ -7,7 +7,7 @@ instanceparam int maxpincount = 32;
 
 instanceparam int pincount = 16;
 
-instanceparam string pinprefix = "";
+instanceparam string iprefix = "";
 
 
 author "Andy Pugh";

--- a/src/hal/i-components/gantry_inst.comp
+++ b/src/hal/i-components/gantry_inst.comp
@@ -55,7 +55,7 @@ instanceparam int maxpincount = 7;
 
 instanceparam int pincount = 7;
 
-instanceparam string pinprefix = "gantry7";
+instanceparam string iprefix = "gantry7";
 
 description """
 Drives multiple physical motors (joints) from a single axis input

--- a/src/hal/i-components/lgantry_inst.comp
+++ b/src/hal/i-components/lgantry_inst.comp
@@ -58,7 +58,7 @@ instanceparam int maxpincount = 7;
 
 instanceparam int pincount = 7;
 
-instanceparam string pinprefix = "lgantry7";
+instanceparam string iprefix = "lgantry7";
 
 description """
 Drives multiple physical motors (joints) from a single axis input

--- a/src/hal/i-components/multiswitch_inst.comp
+++ b/src/hal/i-components/multiswitch_inst.comp
@@ -34,7 +34,7 @@ instanceparam int maxpincount = 32;
 
 instanceparam int pincount = 6;
 
-instanceparam string pinprefix = "mswitch6";
+instanceparam string iprefix = "mswitch6";
 
 
 function _ ;

--- a/src/hal/i-components/xthread.comp
+++ b/src/hal/i-components/xthread.comp
@@ -18,7 +18,7 @@ instanceparam int pincount = 8;
     // The default name for the new instantiation 
     // Pins will have name used to create it on the halcmd line
     // This param will change that name
-instanceparam string pinprefix = "compnew";
+instanceparam string iprefix = "compnew";
 
 option extra_inst_setup;
 option extra_inst_cleanup;


### PR DESCRIPTION
Tests to check for array usage plus a non zero value in maxpins

All examples and instcomp.g now use
instparam string iprefix=""
for per instance pin, param, thread etc prefixes

Signed-off-by: Mick <arceye@mgware.co.uk>