### PR TITLE
Fixed typo in instcomp.asciidoc and corresponding html file

### DIFF
--- a/src/hal/icomp-example/instcomp.asciidoc
+++ b/src/hal/icomp-example/instcomp.asciidoc
@@ -192,7 +192,7 @@ Example 1a.
 
 In the same component, if pincount is supplied as an argument to the newinst call,
 
-it overrules the preset number of pins in arrays using 'pinprefix' as an index,
+it overrules the preset number of pins in arrays using 'pincount' as an index,
 
 up to a maximum (maxpincount) which was set in the .comp file and fixed when the component base was compiled
 

--- a/src/hal/icomp-example/instcomp.html
+++ b/src/hal/icomp-example/instcomp.html
@@ -334,7 +334,7 @@ or pincount, whichever is greater</p>
 <p>In the same component, if pincount is supplied as an argument to the newinst call,</p>
 </div>
 <div class="paragraph">
-<p>it overrules the preset number of pins in arrays using <em>pinprefix</em> as an index,</p>
+<p>it overrules the preset number of pins in arrays using <em>pincount</em> as an index,</p>
 </div>
 <div class="paragraph">
 <p>up to a maximum (maxpincount) which was set in the .comp file and fixed when the component base was compiled</p>
@@ -696,7 +696,7 @@ int x;
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-05-10 12:50:57 BST
+Last updated 2015-05-15 12:53:17 BST
 </div>
 </div>
 </body>


### PR DESCRIPTION
pinprefix used where pincount intended