### PR TITLE
Up maxpincount from 8 to 16

### DIFF
--- a/src/hal/i_components/debounce.icomp
+++ b/src/hal/i_components/debounce.icomp
@@ -9,7 +9,7 @@ param rw s32 delay = 5;
 
 instanceparam int maxpincount = 16;
 
-instanceparam int pincount = 2;
+instanceparam int pincount = 8;
 
 license "GPL";
 

--- a/src/hal/i_components/debounce.icomp
+++ b/src/hal/i_components/debounce.icomp
@@ -7,7 +7,7 @@ param rw s32 #.state[pincount];
 
 param rw s32 delay = 5;
 
-instanceparam int maxpincount = 8;
+instanceparam int maxpincount = 16;
 
 instanceparam int pincount = 2;
 


### PR DESCRIPTION
Allows > 8 filters in one component with same delay
eg
3 axis mill with 3x max/min limits & 3x homes needs 9

Signed-off-by: Mick <arceye@mgware.co.uk>