### PR TITLE
HAL names uniqueness across types

### DIFF
--- a/src/hal/i_components/at_pid.icomp
+++ b/src/hal/i_components/at_pid.icomp
@@ -313,7 +313,7 @@ hal_float_t  prevCmdD, lerror, loutput;
 
     if(state != STATE_PID){
         Pid_AutoTune(arg, period);
-        return;
+        return 0;
     }
 
     // Calculate the error.
@@ -338,7 +338,7 @@ hal_float_t  prevCmdD, lerror, loutput;
         // Switch to tuning mode.
         state = STATE_TUNE_IDLE;
 
-        return;
+        return 0;
     }
 
     // Precalculate some timing constants.
@@ -412,7 +412,7 @@ hal_float_t  prevCmdD, lerror, loutput;
         output = 0;
         limitState = 0;
 
-        return;
+        return 0;
     }
 
     // If output is in limit, don't let integrator wind up.

--- a/src/hal/lib/hal_funct.c
+++ b/src/hal/lib/hal_funct.c
@@ -243,6 +243,8 @@ int hal_add_funct_to_thread(const char *funct_name,
     hal_list_t *list_root, *list_entry;
     int n;
     hal_funct_entry_t *funct_entry;
+    char buff[HAL_NAME_LEN + 1];  
+    rtapi_snprintf(buff, HAL_NAME_LEN, "%s.funct", funct_name);
 
     CHECK_HALDATA();
     CHECK_LOCK(HAL_LOCK_CONFIG);
@@ -266,8 +268,13 @@ int hal_add_funct_to_thread(const char *funct_name,
 	/* search function list for the function */
 	funct = halpr_find_funct_by_name(funct_name);
 	if (funct == 0) {
-	    HALERR("function '%s' not found", funct_name);
-	    return -EINVAL;
+	    funct = halpr_find_funct_by_name((const char*)buff);
+	    if (funct == 0) {
+			HALERR("function '%s' not found", funct_name);
+			return -EINVAL;
+		}
+		else 
+			HALWARN("'%s' should be added to thread as '%s' ", funct_name, buff);
 	}
 	// type-check the functions which go onto threads
 	switch (funct->type) {
@@ -349,7 +356,10 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     hal_funct_t *funct;
     hal_list_t *list_root, *list_entry;
     hal_funct_entry_t *funct_entry;
-
+    
+    char buff[HAL_NAME_LEN + 1];  
+    rtapi_snprintf(buff, HAL_NAME_LEN, "%s.funct", funct_name);
+    
     CHECK_HALDATA();
     CHECK_LOCK(HAL_LOCK_CONFIG);
     CHECK_STR(funct_name);
@@ -365,8 +375,11 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
 	/* search function list for the function */
 	funct = halpr_find_funct_by_name(funct_name);
 	if (funct == 0) {
-	    HALERR("function '%s' not found", funct_name);
-	    return -EINVAL;
+	    funct = halpr_find_funct_by_name((const char*)buff);
+	    if (funct == 0) {
+			HALERR("function '%s' not found", funct_name);
+			return -EINVAL;
+		}
 	}
 	/* found the function, is it in use? */
 	if (funct->users == 0) {

--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -678,9 +678,9 @@ static int comp_id;
         print >>f, "        .owner_id = owner_id"
         print >>f, "        };\n"
 
-        strng = " rtapi_snprintf(buf, sizeof(buf),\"%s"
+        strng = "    rtapi_snprintf(buf, sizeof(buf),\"%s"
         if (len(functions) == 1) and name == "_":
-            strng += "\", name);"
+            strng += ".funct\", name);"
         else :
             strng += ".%s\", name);" % (to_hal(name))
         print >>f, strng
@@ -786,7 +786,7 @@ static int comp_id;
 #    print >>f, "        .owner_id = comp_id"
 #    print >>f, "        };\n"
 #
-#    print >>f, "    if (hal_export_xfunctf(&xtf,\"%s.funct\", compname))"
+#    print >>f, "    if (hal_export_xfunctf(&xtf,\"%s.rtfunct\", compname))"
 #    print >>f, "        return -1;"
 ##################################################################################
 


### PR DESCRIPTION
Make default function name unique by appending .funct to the function

Changes to hal_funct.c to allow adding to thread by default name
which is corrected and warning issued

Minor change to at_pid to ensure all returns, 'return 0;'

Signed-off-by: Mick <arceye@mgware.co.uk>