### PR TITLE
instcomp changes to use <type>_pin_ptr

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1469,8 +1469,8 @@ obj-m += icomp.o
 icomp-objs := hal/icomp-example/icomp.o
 
 # clashes with component in i_components
-obj-m += lutnv2.o
-lutnv2-objs := hal/icomp-example/lutnv2.o
+#obj-m += lutnv2.o
+#lutnv2-objs := hal/icomp-example/lutnv2.o
 
 obj-m += plug.o
 plug-objs := hal/icomp-example/plug.o
@@ -1657,8 +1657,8 @@ $(RTLIBDIR)/tp$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(tp-objs))
 $(RTLIBDIR)/ufdemo$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(ufdemo-objs))
 $(RTLIBDIR)/icomp$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(icomp-objs))
 $(RTLIBDIR)/plug$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(plug-objs))
-$(RTLIBDIR)/lutn$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(lutn-objs))
-$(RTLIBDIR)/lutnv2$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(lutnv2-objs))
+#$(RTLIBDIR)/lutn$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(lutn-objs))
+#$(RTLIBDIR)/lutnv2$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(lutnv2-objs))
 
 ifeq ($(TRIVIAL_BUILD),no)
 READ_RTDEPS = $(wildcard $(RTDEPS))

--- a/src/hal/i_components/andn.icomp
+++ b/src/hal/i_components/andn.icomp
@@ -24,7 +24,7 @@ FUNCTION(_)
     hal_bit_t value = true;
 
     // loop through inputs
-    for (n = 0; n < localpincount; n++)
+    for (n = 0; n < local_pincount; n++)
     {
         value = value && in_(n);
     }

--- a/src/hal/i_components/bitslice.icomp
+++ b/src/hal/i_components/bitslice.icomp
@@ -16,7 +16,7 @@ function _ nofp;
 FUNCTION(_)
 {
 hal_s32_t i;
-    for (i = 0; i < localpincount ; i++)
+    for (i = 0; i < local_pincount ; i++)
         out(i) = (in >> i)&1;
 
 return 0;

--- a/src/hal/i_components/debounce.icomp
+++ b/src/hal/i_components/debounce.icomp
@@ -28,7 +28,7 @@ hal_s32_t n;
         delay = 1;
 
     // loop through filters
-    for (n = 0; n < localpincount; n++)
+    for (n = 0; n < local_pincount; n++)
         {
         if(_in(n))
             {

--- a/src/hal/i_components/gantry.icomp
+++ b/src/hal/i_components/gantry.icomp
@@ -94,7 +94,7 @@ FUNCTION(read) {
     limit=joint_home(0);
 
     // All other joints, if configured
-    while (i < localpincount) {
+    while (i < local_pincount) {
         // Check to see if machine is in latching state
         if(!latching)
         {
@@ -121,15 +121,15 @@ FUNCTION(read) {
     // stop.  If all joints are not homed, but the current joint used
     // for feedback is, find a joint that's still active
     if ((joint_home(fb_joint) ) && (home == 0)) {
-        for (i=0; i < localpincount; i++) {
+        for (i=0; i < local_pincount; i++) {
             if (!joint_home(i)) {
-                position_fb = joint_pos_fb(i) + offset[i];
+                position_fb = joint_pos_fb(i) + offset(i);
                 fb_joint = i;
                 break;
             }
         }
     } else {
-        position_fb = joint_pos_fb(fb_joint) + offset[fb_joint];
+        position_fb = joint_pos_fb(fb_joint) + offset(fb_joint);
     }
 
 	return 0;
@@ -155,19 +155,19 @@ FUNCTION(write) {
     // If we're moving towards home and all home switches are not closed
     if ( ((delta * search_vel) > 0) && (home==0) ) {
         // Check each joint to see if it's home switch is active
-        for (i=0; i < localpincount; i++) {
+        for (i=0; i < local_pincount; i++) {
             // If home switch is active, update offset, not pos_cmd
             // so the other joints can catch up
             if (joint_home(i)) {
-                offset[i] += delta;
+                offset(i) += delta;
             }
         }
     }
 
     // Update each joint's commanded position
-    for (i=0; i < localpincount; i++) {
-        joint_pos_cmd(i) = position_cmd - offset[i];
-        joint_offset(i)  = offset[i];
+    for (i=0; i < local_pincount; i++) {
+        joint_pos_cmd(i) = position_cmd - offset(i);
+        joint_offset(i)  = offset(i);
     }
 
 	return 0;

--- a/src/hal/i_components/io_muxn.icomp
+++ b/src/hal/i_components/io_muxn.icomp
@@ -55,7 +55,7 @@ author "Alexander Roessler";
 ;;
 FUNCTION(_)
 {
-    if ((sel < 0) || (sel >= localpincount))
+    if ((sel < 0) || (sel >= local_pincount))
     {
         return 0; // incorrect sel, we change nothing
     }

--- a/src/hal/i_components/latencybins.icomp
+++ b/src/hal/i_components/latencybins.icomp
@@ -76,7 +76,7 @@ if (   first
   latency = 0;
   pextra = 0; nextra = 0;
   for (i = 0; i <= binmax; i++) {
-    pbins[i] = 0; nbins[i] = 0;
+    pbins(i) = 0; nbins(i) = 0;
   }
 } else {
   latency = lat32;
@@ -85,14 +85,14 @@ if (   first
      if (i > binmax) {
        pextra++;
      } else {
-       pbins[i]++;
+       pbins(i)++;
      }
   } else {
      i = -i;
      if (i > binmax) {
        nextra++;
      } else {
-       nbins[i]++;
+       nbins(i)++;
      }
   }
 }
@@ -103,8 +103,8 @@ if (index < 0) {
   pbinvalue = -1;
   nbinvalue = -1;
 } else if (index <=binmax) {
-  pbinvalue = pbins[index];
-  nbinvalue = nbins[index];
+  pbinvalue = pbins(index);
+  nbinvalue = nbins(index);
 } else {
   pbinvalue = -1;
   nbinvalue = -1;

--- a/src/hal/i_components/lgantry.icomp
+++ b/src/hal/i_components/lgantry.icomp
@@ -111,27 +111,27 @@ FUNCTION(read)
     limit = false;
 
     // All other joints, if configured
-    for (i = 0; i < localpincount; i++) {
+    for (i = 0; i < local_pincount; i++) {
         // check to see if machine is in home state
         if(previous_home == 0) {
             // Once all joints are within proximity of homing switches,
             // the home sequence begins
-            curr_home[i] = joint_home(i);
-            home &= curr_home[i];
+            curr_home(i) = joint_home(i);
+            home &= curr_home(i);
             // Stash per joint home state for next cycle
-            prev_home[i] = curr_home[i];
+            prev_home(i) = curr_home(i);
         }
         else {
             // Use the offset to introduce a additional per joint calibration value
             // target offset is calculated when home state changes
-            if (prev_home[i] != joint_home(i)) {
-                prev_home[i] = joint_home(i);
-                pos_fb_target[i] = joint_pos_fb(i) + joint_home_offset(i);
+            if (prev_home(i) != joint_home(i)) {
+                prev_home(i) = joint_home(i);
+                pos_fb_target(i) = joint_pos_fb(i) + joint_home_offset(i);
             }
             // Once all joints come out of proximity, reset home switch
             // so machine will run normal again.
-            curr_home[i] = joint_home(i) | (joint_pos_fb(i) < pos_fb_target[i]);
-            home |= curr_home[i];
+            curr_home(i) = joint_home(i) | (joint_pos_fb(i) < pos_fb_target(i));
+            home |= curr_home(i);
         }
         limit |= joint_home(i);
     }
@@ -142,13 +142,13 @@ FUNCTION(read)
     // within proximity of the homing switch when not in home mode.
     // Feedback joint will use the first joint that IS in proximity of
     // homing switch.
-    for (i = 0; i < localpincount; i++) {
+    for (i = 0; i < local_pincount; i++) {
         if (joint_home(i) == home) {
             fb_joint = i;
             break;
         }
     }
-    position_fb = joint_pos_fb(fb_joint) + offset[fb_joint];
+    position_fb = joint_pos_fb(fb_joint) + offset(fb_joint);
 
 return 0;
 }
@@ -176,21 +176,21 @@ FUNCTION(write)
         // If we're moving towards home and all home switches are not closed
         if ((((delta * search_vel) > 0) && (home == 0)) || (home == 1)) {
             // Check each joint to see if it's home switch is active
-            for (i = 0; i < localpincount; i++) {
+            for (i = 0; i < local_pincount; i++) {
                 // If home switch is active but system not in home mode,
                 // update offset, not pos_cmd so the other joints can catch up
                 // When home, this happens when home switch is inactive
-                if (curr_home[i] != home) {
-                    offset[i] += delta;
+                if (curr_home(i) != home) {
+                    offset(i) += delta;
                 }
             }
         }
     }
 
     // Update each joint's commanded position
-    for (i = 0; i < localpincount; i++) {
-        joint_pos_cmd(i) = position_cmd - offset[i];
-        joint_offset(i) = offset[i];
+    for (i = 0; i < local_pincount; i++) {
+        joint_pos_cmd(i) = position_cmd - offset(i);
+        joint_offset(i) = offset(i);
     }
 
 return 0;

--- a/src/hal/i_components/lincurve.icomp
+++ b/src/hal/i_components/lincurve.icomp
@@ -43,8 +43,8 @@ FUNCTION(_)
 {
     hal_float_t f, x;
     x = in_;
-    if (x >= x_val(localpincount-1)) {
-        out_ = y_val(localpincount-1);
+    if (x >= x_val(local_pincount-1)) {
+        out_ = y_val(local_pincount-1);
         out_io = out_;
         return 0;
     }
@@ -64,7 +64,7 @@ return 0;
 }
 
 EXTRA_INST_SETUP(){
-//	if (localpincount > 16) localpincount = 16;
-	if (localpincount < 2) localpincount = 2;
+//	if (local_pincount > 16) local_pincount = 16;
+	if (local_pincount < 2) local_pincount = 2;
 	return 0;
 }

--- a/src/hal/i_components/lutn.icomp
+++ b/src/hal/i_components/lutn.icomp
@@ -24,7 +24,7 @@ hal_u32_t i;
 ip = arg;
 hal_u32_t shift = 0;
 
-    for (i = 0; i < localpincount; i++)
+    for (i = 0; i < local_pincount; i++)
 	if (in(i))
 	    shift += (1 << i);
 

--- a/src/hal/i_components/lutnv2.icomp
+++ b/src/hal/i_components/lutnv2.icomp
@@ -1,0 +1,30 @@
+component lutnv2;
+
+pin_ptr out bit out = 0;
+pin_ptr in bit in#[pincount] = 0;
+    
+instanceparam int pincount = 2      "number of input pins, in0..inN";
+
+option MAXCOUNT 5;
+
+instanceparam int functn = 255      "lookup function - see man lut5";
+
+function _;
+
+author          "Michael Haberler";
+description     "LUT component with configurable number of pins";
+license         "GPLv2 or later";
+;;
+
+FUNCTION(_) 
+{
+hal_u32_t i, shift = 0;
+ip = arg;
+
+    for (i = 0; i < local_pincount; i++)
+        if (get_bit_pin(in(i))) shift += (1 << i);
+
+    set_bit_pin(out, (local_functn & (1 << shift)) != 0);
+   
+    return 0;
+}

--- a/src/hal/i_components/multiswitch.icomp
+++ b/src/hal/i_components/multiswitch.icomp
@@ -59,7 +59,7 @@ FUNCTION(_)
     if (position < 0) position = top_position;
     if (position > top_position) position = 0;
 
-    for (i = 0 ; i < localpincount; i++)
+    for (i = 0 ; i < local_pincount; i++)
         {
         bit(i) = (i == position);
         }
@@ -70,6 +70,6 @@ return 0;
 
 EXTRA_INST_SETUP()
 {
-    top_position = localpincount - 1;
+    top_position = local_pincount - 1;
     return 0;
 }

--- a/src/hal/i_components/muxn.icomp
+++ b/src/hal/i_components/muxn.icomp
@@ -14,7 +14,7 @@ author "Alexander Roessler";
 ;;
 FUNCTION(_)
 {
-    if ((sel >= 0) && (sel < localpincount))
+    if ((sel >= 0) && (sel < local_pincount))
     {
         out = in_(sel);
     }

--- a/src/hal/i_components/muxn_u32.icomp
+++ b/src/hal/i_components/muxn_u32.icomp
@@ -14,7 +14,7 @@ author "Alexander Roessler";
 ;;
 FUNCTION(_)
 {
-    if ((sel >= 0) && (sel < localpincount))
+    if ((sel >= 0) && (sel < local_pincount))
     {
         out = in_(sel);
     }

--- a/src/hal/i_components/orn.icomp
+++ b/src/hal/i_components/orn.icomp
@@ -24,7 +24,7 @@ FUNCTION(_)
     hal_bit_t value = false;
 
     // loop through inputs
-    for (n = 0; n < localpincount; n++)
+    for (n = 0; n < local_pincount; n++)
     {
         value = value || in_(n);
     }

--- a/src/hal/i_components/selectn.icomp
+++ b/src/hal/i_components/selectn.icomp
@@ -14,7 +14,7 @@ author "Alexander Roessler";
 FUNCTION(_)
 {
     hal_s32_t i;
-    for (i=0; i < localpincount ; i++)
+    for (i=0; i < local_pincount ; i++)
     {
         if (!enable || (sel != i))
         {

--- a/src/hal/i_components/wcompn.icomp
+++ b/src/hal/i_components/wcompn.icomp
@@ -20,7 +20,7 @@ FUNCTION(_)
     hal_s32_t i;
 
     out = default_out;
-    for (i=1; i < localpincount; i++)
+    for (i=1; i < local_pincount; i++)
     {
         if ((in >= value(i-1)) && (in < value(i)))
         {
@@ -28,7 +28,7 @@ FUNCTION(_)
         }
     }
     under = (in < value(0));
-    over = (in >= value(localpincount-1));
+    over = (in >= value(local_pincount-1));
     in_range = !(under || over);
 
     return 0;

--- a/src/hal/i_components/weighted_sum.icomp
+++ b/src/hal/i_components/weighted_sum.icomp
@@ -64,7 +64,7 @@ hal_s32_t b, running_total;
 	if (!hold) 
 		{
 		running_total = offset;
-		for (b=0 ; b < localpincount ; b++) 
+		for (b=0 ; b < local_pincount ; b++) 
 			{
 			if (in(b)) 
 				running_total += weight(b);

--- a/src/hal/icomp-example/barr-propagation-demo-icomp.hal
+++ b/src/hal/icomp-example/barr-propagation-demo-icomp.hal
@@ -1,0 +1,107 @@
+# define some signals
+newsig s1 bit
+newsig s2 bit
+
+show sig
+# Signals:
+# Type          Value  MB Name    linked to:
+# bit           FALSE  -- s1
+# bit           FALSE  -- s2
+
+
+# manipulate barrier bits:
+setwmb s1
+setrmb s1
+
+# do the same on second signal
+setwmb s2
+setrmb s2
+
+show sig
+# Signals:
+# Type          Value  MB Name    linked to:
+# bit           FALSE  rw s1
+# bit           FALSE  rw s2
+
+
+
+# this newinst creates some v2 pins which support barrier propagation
+# NB no barriers initally set
+newinst lutnv2  test pincount=2 functn=0x0e
+
+show pin
+# Component Pins:
+#   Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+#     80     82 s32   OUT             0  test.funct.time               		--	0
+#     80     82 bit   IN          FALSE  test.in0                      		--	0
+#     80     82 bit   IN          FALSE  test.in1                      		--	0
+#     80     82 bit   OUT         FALSE  test.out                      		--	0
+
+
+
+# show barrier propagation by linking s1 and s2 to test.in0 and test.out
+
+net s1 test.in0
+net s2 test.out
+
+# hal/icomp-example/barrier-propagation-demo.hal:42: Pin 'test.in0' linked to signal 's1'
+# hal/icomp-example/barrier-propagation-demo.hal:43: Pin 'test.out' linked to signal 's2'
+# Component Pins:
+#   Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+#     80     82 s32   OUT             0  test.funct.time               		--	0
+#     80     82 bit   IN          FALSE  test.in0                      		r-	0	<== s1
+#     80     82 bit   IN          FALSE  test.in1                      		--	0
+#     80     82 bit   OUT         FALSE  test.out                      		-w	0	==> s2
+
+
+# log with DEBUG=5:
+
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6546:user halg_signal_new:22 HAL: creating signal 's1'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6546:user halg_signal_new:22 HAL: creating signal 's2'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6546:user halg_object_setbarriers:310 HAL: setting barriers on SIGNAL 's1': rmb: 0->0  wmb: 0->1
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6546:user halg_object_setbarriers:310 HAL: setting barriers on SIGNAL 's1': rmb: 0->1  wmb: 1->1
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6546:user halg_object_setbarriers:310 HAL: setting barriers on SIGNAL 's2': rmb: 0->0  wmb: 0->1
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6546:user halg_object_setbarriers:310 HAL: setting barriers on SIGNAL 's2': rmb: 0->1  wmb: 1->1
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt halg_xinit:69 HAL: initializing component 'lutnv2' type=1 arg1=0 arg2=0/0x0
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt halg_xinit:247 HAL: instantiable component 'lutnv2' id=80 initialized
+# Jul 28 20:43:18 nwheezy msgd:0: rtapi_app:6540:user lutnv2: loaded from lutnv2.so
+# Jul 28 20:43:18 nwheezy msgd:0: rtapi_app:6540:user do_newinst_cmd: instargs='inputs=2 function=0x0e'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt halg_inst_create:60 HAL: rtapi: creating instance 'test' size 20
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt instantiate_lutn: name='test' inputs=2 function=0xe ip=0xb6c59fe8
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt halg_pin_new:139 HAL: creating pin 'test.in0'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt halg_pin_new:139 HAL: creating pin 'test.in1'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt halg_pin_new:139 HAL: creating pin 'test.out'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt hal_export_xfunctfv:70 HAL: exporting function 'test.funct' type 1
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt halg_pin_new:139 HAL: creating pin 'test.funct.time'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt hal_param_new:132 HAL: creating parameter 'test.funct.tmax'
+# Jul 28 20:43:18 nwheezy msgd:0: hal_lib:6540:rt hal_param_new:132 HAL: creating parameter 'test.funct.tmax-inc'
+# Jul 28 20:40:29 nwheezy msgd:0: hal_lib:6486:user halg_link:235 HAL: linking pin 'test.in0' to 's1'
+# Jul 28 20:40:29 nwheezy msgd:0: hal_lib:6486:user propagate_barriers_cb:165 HAL: propagating barriers from signal 's1' to pin 'test.in0': rmb: 0->1  wmb: 0->0
+# Jul 28 20:40:29 nwheezy msgd:0: hal_lib:6486:user halg_link:235 HAL: linking pin 'test.out' to 's2'
+# Jul 28 20:40:29 nwheezy msgd:0: hal_lib:6486:user propagate_barriers_cb:165 HAL: propagating barriers from signal 's2' to pin 'test.out': rmb: 0->0  wmb: 0->1
+
+# one can set rmb/wmb on any hal object, just because the bits are there
+# no use case yet
+newthread foo 1000000
+setrmb foo
+setwmb foo
+
+show objects
+# COMPONENT hal_lib id=66 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# FUNCT delinst id=69 owner=66 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# FUNCT newinst id=68 owner=66 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# COMPONENT hal_lib6546 id=74 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# COMPONENT halcmd6546 id=76 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# SIGNAL s1 id=78 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+# SIGNAL s2 id=79 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+# COMPONENT lutnv2 id=80 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# INST test id=82 owner=80 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# PIN test.funct.time id=87 owner=82 valid=1 refcnt=0 legacy=1 rmb=0 wmb=0
+# PIN test.in0 id=83 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# PIN test.in1 id=84 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# PIN test.out id=85 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# FUNCT test.funct id=86 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# PARAM test.funct.tmax id=88 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# PARAM test.funct.tmax-inc id=89 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+# THREAD foo id=90 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+#    ------------------------------------------------^^^^^^^^^^^

--- a/src/hal/icomp-example/lutn-demo-icomp.hal
+++ b/src/hal/icomp-example/lutn-demo-icomp.hal
@@ -1,0 +1,71 @@
+newsig in0 bit
+newsig in1 bit
+# just to show barrier propagation in the log:
+# (the propagation is repeated for all pins on every link)
+setrmb in0
+setwmb in1
+
+
+newinst lutnv2 or2.0  pincount=2 functn=0xe
+newinst lutnv2 and2.0 pincount=2 functn=0x8
+
+net in0 and2.0.in0 or2.0.in0
+net in1 and2.0.in1 or2.0.in1
+
+newthread servo 1000000 fp
+addf or2.0.funct 	servo
+addf and2.0.funct 	servo
+start
+
+show sig in0 in1
+show pin or2.0.out and2.0.out
+
+sets in0 1
+show sig in0 in1
+show pin or2.0.out and2.0.out
+
+sets in1 1
+show sig in0 in1
+show pin or2.0.out and2.0.out
+
+sets in0 0
+show sig in0 in1
+show pin or2.0.out and2.0.out
+
+sets in1 0
+show sig in0 in1
+show pin or2.0.out and2.0.out
+
+
+
+
+
+
+
+# show pin or2.0.out and2.0.out
+# show pin
+
+# setp or2.0.in0 0
+# setp or2.0.in1 1
+
+# show pin or2.0.out
+
+# setp or2.0.in1 0
+# show pin or2.0.out
+
+# show pin and2.0*
+
+# setp and2.0.in0 1
+# show pin and2.0.out
+
+# setp and2.0.in1 1
+# show pin and2.0.out
+
+# setp and2.0.in1 0
+# show pin and2.0.out
+
+# delinst or2.0
+# show pin
+
+# delinst and2.0
+# show pin

--- a/src/hal/icomp-example/output-icomp.txt
+++ b/src/hal/icomp-example/output-icomp.txt
@@ -1,0 +1,131 @@
+mick@INTEL-i7:/usr/src/machinekit-arceye/src/hal/icomp-example$ halcmd -f lutn-demo.hal
+lutn-demo.hal:9: Realtime module 'lutnv2' loaded
+lutn-demo.hal:12: Pin 'and2.0.in0' linked to signal 'in0'
+lutn-demo.hal:12: Pin 'or2.0.in0' linked to signal 'in0'
+lutn-demo.hal:13: Pin 'and2.0.in1' linked to signal 'in1'
+lutn-demo.hal:13: Pin 'or2.0.in1' linked to signal 'in1'
+lutn-demo.hal:16: Function 'or2.0.funct' added to thread 'servo', rmb=0 wmb=0
+lutn-demo.hal:17: Function 'and2.0.funct' added to thread 'servo', rmb=0 wmb=0
+lutn-demo.hal:18: Realtime threads started
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit           FALSE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:23: Signal 'in0' set to 1
+Signals:
+Type          Value  MB Name    linked to:
+bit            TRUE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit           FALSE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:27: Signal 'in1' set to 1
+Signals:
+Type          Value  MB Name    linked to:
+bit            TRUE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit            TRUE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:31: Signal 'in0' set to 0
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit            TRUE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:35: Signal 'in1' set to 0
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit           FALSE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+
+
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+
+
+mick@INTEL-i7:/usr/src/machinekit-arceye/src/hal/icomp-example$ halcmd -f barrier-propagation-demo.hal
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  -- s1 
+bit           FALSE  -- s2 
+
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  rw s1 
+bit           FALSE  rw s2 
+
+barrier-propagation-demo.hal:30: Realtime module 'lutnv2' loaded
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     82 s32   OUT             0  test.funct.time               		--	0
+    80     82 bit   IN          FALSE  test.in0                      		--	0
+    80     82 bit   IN          FALSE  test.in1                      		--	0
+    80     82 bit   OUT         FALSE  test.out                      		--	0
+
+barrier-propagation-demo.hal:44: Pin 'test.in0' linked to signal 's1'
+barrier-propagation-demo.hal:45: Pin 'test.out' linked to signal 's2'
+COMPONENT hal_lib id=66 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+FUNCT delinst id=69 owner=66 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+FUNCT newinst id=68 owner=66 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+COMPONENT hal_lib29985 id=74 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+COMPONENT halcmd29985 id=76 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+SIGNAL s1 id=78 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+SIGNAL s2 id=79 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+COMPONENT lutnv2 id=80 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+INST test id=82 owner=80 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PIN test.funct.time id=87 owner=82 valid=1 refcnt=0 legacy=1 rmb=0 wmb=0
+PIN test.in0 id=84 owner=82 valid=1 refcnt=0 legacy=0 rmb=1 wmb=0
+PIN test.in1 id=85 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PIN test.out id=83 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=1
+FUNCT test.funct id=86 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PARAM test.funct.tmax id=88 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PARAM test.funct.tmax-inc id=89 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+THREAD foo id=90 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+
+
+
+

--- a/src/hal/icomp-example/output.txt
+++ b/src/hal/icomp-example/output.txt
@@ -1,0 +1,135 @@
+
+mick@INTEL-i7:/usr/src/machinekit-arceye/src/hal/icomp-example$ halcmd -f lutn-demo.hal
+lutn-demo.hal:9: Realtime module 'lutnv2' loaded
+lutn-demo.hal:12: Pin 'and2.0.in0' linked to signal 'in0'
+lutn-demo.hal:12: Pin 'or2.0.in0' linked to signal 'in0'
+lutn-demo.hal:13: Pin 'and2.0.in1' linked to signal 'in1'
+lutn-demo.hal:13: Pin 'or2.0.in1' linked to signal 'in1'
+lutn-demo.hal:16: Function 'or2.0.funct' added to thread 'servo', rmb=0 wmb=0
+lutn-demo.hal:17: Function 'and2.0.funct' added to thread 'servo', rmb=0 wmb=0
+lutn-demo.hal:18: Realtime threads started
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit           FALSE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:23: Signal 'in0' set to 1
+Signals:
+Type          Value  MB Name    linked to:
+bit            TRUE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit           FALSE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:27: Signal 'in1' set to 1
+Signals:
+Type          Value  MB Name    linked to:
+bit            TRUE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit            TRUE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:31: Signal 'in0' set to 0
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit            TRUE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+lutn-demo.hal:35: Signal 'in1' set to 0
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  r- in0 
+                                 ==> and2.0.in0
+                                 ==> or2.0.in0
+bit           FALSE  -w in1 
+                                 ==> and2.0.in1
+                                 ==> or2.0.in1
+
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     90 bit   OUT         FALSE  and2.0.out                    		--	0
+    80     82 bit   OUT         FALSE  or2.0.out                     		--	0
+
+
+
+#############################################################################################################
+
+Error in barrier-propogation.hal - non english keyset
+
+barrier-propagation-demo.hal:32: Unknown 'show' type 'piń'
+
+#############################################################################################################
+
+
+mick@INTEL-i7:/usr/src/machinekit-arceye/src/hal/icomp-example$ halcmd -f barrier-propagation-demo.hal
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  -- s1 
+bit           FALSE  -- s2 
+
+Signals:
+Type          Value  MB Name    linked to:
+bit           FALSE  rw s1 
+bit           FALSE  rw s2 
+
+barrier-propagation-demo.hal:30: Realtime module 'lutnv2' loaded
+Component Pins:
+  Comp   Inst Type  Dir         Value  Name                             Epsilon MB  Flags   linked to:
+    80     82 s32   OUT             0  test.funct.time               		--	0
+    80     82 bit   IN          FALSE  test.in0                      		--	0
+    80     82 bit   IN          FALSE  test.in1                      		--	0
+    80     82 bit   OUT         FALSE  test.out                      		--	0
+
+barrier-propagation-demo.hal:44: Pin 'test.in0' linked to signal 's1'
+barrier-propagation-demo.hal:45: Pin 'test.out' linked to signal 's2'
+COMPONENT hal_lib id=66 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+FUNCT delinst id=69 owner=66 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+FUNCT newinst id=68 owner=66 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+COMPONENT hal_lib11531 id=74 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+COMPONENT halcmd11531 id=76 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+SIGNAL s1 id=78 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+SIGNAL s2 id=79 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+COMPONENT lutnv2 id=80 owner=0 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+INST test id=82 owner=80 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PIN test.funct.time id=87 owner=82 valid=1 refcnt=0 legacy=1 rmb=0 wmb=0
+PIN test.in0 id=83 owner=82 valid=1 refcnt=0 legacy=0 rmb=1 wmb=0
+PIN test.in1 id=84 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PIN test.out id=85 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=1
+FUNCT test.funct id=86 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PARAM test.funct.tmax id=88 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+PARAM test.funct.tmax-inc id=89 owner=82 valid=1 refcnt=0 legacy=0 rmb=0 wmb=0
+THREAD foo id=90 owner=0 valid=1 refcnt=0 legacy=0 rmb=1 wmb=1
+
+


### PR DESCRIPTION
Allows creation of pins and access to them via pin_ptr types

Various other misc changes to instcomp:
User defined types allowed as userdef_type
User defined includes as userdef_include to cater for definition of the types

New lutnv2.icomp demonstrating pin_ptr usage

Changes to various other .icomps to reflect new naming standard
for local copies of instanceparam values

Signed-off-by: Mick <arceye@mgware.co.uk>