### PR TITLE
instcomp changes - remove param pin processing

### DIFF
--- a/src/hal/i_components/mux4v2.icomp
+++ b/src/hal/i_components/mux4v2.icomp
@@ -1,4 +1,4 @@
-component mux4 "Select from one of four input values";
+component mux4v2 "Select from one of four input values";
 pin_ptr in bit sel0;
 pin_ptr in bit sel1 """\
 Together, these determine which \\fBin\\fIN\\fR value is copied to \\fBout\\fR.

--- a/src/hal/i_components/muxnv2.icomp
+++ b/src/hal/i_components/muxnv2.icomp
@@ -1,4 +1,4 @@
-component muxn "Select from one of N input values";
+component muxnv2 "Select from one of N input values";
 pin_ptr in s32 sel = 0;
 pin_ptr out float out "Follows the value of \\fBin<M>\\fR whereas M is the value of the \\fBsel\\fR input. \
 If \\fBsel\\fR is not in the range of available inputs 0 is output.";

--- a/src/hal/i_components/threadtestv2.icomp
+++ b/src/hal/i_components/threadtestv2.icomp
@@ -1,4 +1,4 @@
-component threadtest "Machinekit HAL component for testing thread behavior";
+component threadtestv2 "Machinekit HAL component for testing thread behavior";
 pin_ptr out u32 count;
 function increment nofp;
 function reset nofp;

--- a/src/hal/i_components/tristate_float.icomp
+++ b/src/hal/i_components/tristate_float.icomp
@@ -1,4 +1,4 @@
-component tristate_floats "Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics";
+component tristate_float "Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics";
 
 pin in float in_ "Input value";
 pin io float out "Output value";

--- a/src/hal/i_components/tristate_floatv2.icomp
+++ b/src/hal/i_components/tristate_floatv2.icomp
@@ -1,4 +1,4 @@
-component tristate_floatsv2 "Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics";
+component tristate_floatv2 "Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics";
 
 pin_ptr in float in_ "Input value";
 pin_ptr io float out "Output value";


### PR DESCRIPTION
params have been deprecated for some time in icomps and none of the
existing icomps use them
With introduction of SMP_SAFE icomps, decided to cease processing
and force use of pins or pin_ptrs with IO type instead in any future
icomps

Added checking that component name matches the filename

Modified several icomps that failed that test and proved it worked!

Signed-off-by: Mick <arceye@mgware.co.uk>