### PR TITLE
Fix typo in instcomp re single string instanceparam args

### DIFF
--- a/src/hal/utils/instcomp.g
+++ b/src/hal/utils/instcomp.g
@@ -786,7 +786,7 @@ def prologue(f):
                 else: 
                     print >>f, "    if(%s != NULL)\n        {" % (to_c(name))
                     print >>f, "        strncpy(buf, %s, HAL_NAME_LEN);" % (to_c(name))
-                    print >>f, "        ip->local_%s = halg_strdup(1, buf);        }" % (to_c(name), to_c(name))
+                    print >>f, "        ip->local_%s = halg_strdup(1, buf);        }" % (to_c(name))
                     print >>f, "    else\n    ip->local_%s = NULL;\n" % (to_c(name))
                                              
     for name, fp in functions:


### PR DESCRIPTION
Signed-off-by: Mick <arceye@mgware.co.uk>