### PR TITLE
Tidy up of C++ example components

### DIFF
--- a/src/hal/icomp-example/C++_userspace_comp/Submakefile
+++ b/src/hal/icomp-example/C++_userspace_comp/Submakefile
@@ -1,7 +1,10 @@
 CONST_DIR := hal/icomp-example/C++_userspace_comp
 
-CONST_SRCS :=  $(addprefix $(CONST_DIR)/, \
+CONSTV2_SRCS :=  $(addprefix $(CONST_DIR)/, \
 	constv2.cc)
+
+CONST_SRCS :=  $(addprefix $(CONST_DIR)/, \
+	const.cc)
 
 CONST_CXXFLAGS := -DULAPI 	\
 	-I$(CONST_DIR)
@@ -9,12 +12,24 @@ CONST_CXXFLAGS := -DULAPI 	\
 CONST_LDFLAGS := \
 	-lstdc++ -lm
 
-$(call TOOBJSDEPS, $(CONST_SRCS)) : EXTRAFLAGS += $(CONST_CXXFLAGS)
+$(call TOOBJSDEPS, $(CONSTV2_SRCS)) : EXTRAFLAGS += $(CONST_CXXFLAGS)
 
-../bin/constv2: $(call TOOBJS, $(CONST_SRCS)) \
+../bin/constv2: $(call TOOBJS, $(CONSTV2_SRCS)) \
 	../lib/liblinuxcnchal.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) -o $@ $^ $(LDFLAGS) $(CONST_LDFLAGS)
 
-USERSRCS += $(CONST_SRCS)
+USERSRCS += $(CONSTV2_SRCS)
 TARGETS += ../bin/constv2
+
+
+$(call TOOBJSDEPS, $(CONST_SRCS)) : EXTRAFLAGS += $(CONST_CXXFLAGS)
+
+../bin/const: $(call TOOBJS, $(CONST_SRCS)) \
+	../lib/liblinuxcnchal.so.0
+	$(ECHO) Linking $(notdir $@)
+	$(Q)$(CC) -o $@ $^ $(LDFLAGS) $(CONST_LDFLAGS)
+
+
+USERSRCS += $(CONST_SRCS)
+TARGETS += ../bin/const

--- a/src/hal/icomp-example/C++_userspace_comp/build
+++ b/src/hal/icomp-example/C++_userspace_comp/build
@@ -1,8 +1,0 @@
-# !/bin/bash
-
-## adjust precise paths to suit
-
-g++ -Os -g -I. -I/usr/src/machinekit/include -I/usr/local/include -D_FORTIFY_SOURCE=0 \
-    -mhard-float -fno-fast-math -mieee-fp -fno-unsafe-math-optimizations -D_GNU_SOURCE \
-    -Wframe-larger-than=2560 -DULAPI -Os \
-     -o $1 $1.cpp -Wl,-rpath,/lib -L/lib -L/usr/src/machinekit/lib -llinuxcncini -llinuxcnchal -lnml -llinuxcnc -lposemath

--- a/src/hal/icomp-example/C++_userspace_comp/const.cc
+++ b/src/hal/icomp-example/C++_userspace_comp/const.cc
@@ -1,11 +1,17 @@
-// C++ implementation of the constant component
-
+/**********************************************************************
+ * Demo of writing a standard userspace component in std C++
+ *
+ * Based on the constant.icomp component
+ *
+ * ArcEye 2015  <arceyeATmgwareDOTcoDOTuk>
+ *
+***********************************************************************/
 
 #include <LCNC_Headers.h>
 
 using namespace std;
 
-struct __comp_state 
+struct __comp_state
     {
     hal_float_t *out;
     hal_float_t *value;
@@ -18,7 +24,7 @@ public:
     Const(int argc, char** argv);
     ~Const();
 
-private:    
+private:
     int connectPins();
     void eventsLoop();
 
@@ -31,19 +37,20 @@ private:
 Const::Const(int argc, char** argv)
 {
 int r;
-    
+
     strcpy(prefix, "const\0");  // used later in pins
     comp_id = hal_init("const");
-    
-    if(comp_id < 0) 
+
+    if(comp_id < 0)
         exit(-1);
-        
-    if((r = connectPins())) 
-        hal_exit(comp_id);    
+
+    if((r = connectPins()))
+        hal_exit(comp_id);
     else
         {
         hal_ready(comp_id);
-        cout << "Component \""<< prefix << "\" registered and ready\n" << "comp_ID = " << comp_id << "\n" << endl;
+        cout << "Component \""<< prefix << "\" registered and ready\n"
+            << "comp_ID = " << comp_id << "\n" << endl;
         }
 
     eventsLoop();
@@ -63,15 +70,15 @@ int sz = sizeof(struct __comp_state) + 2;  //fudge factor
 
     inst = (struct __comp_state*)hal_malloc(sz);
     memset(inst, 0, sz);
-    
+
     if( (r = hal_pin_float_newf(HAL_OUT, &(inst->out), comp_id,"%s.out", prefix)) != 0)
         return -1;
-  
+
     *(inst->out) = 0.0;
-    
+
     if( (r = hal_pin_float_newf(HAL_IN, &(inst->value), comp_id,"%s.value", prefix)) != 0)
         return -1;
-  
+
     *(inst->value) = 0.0;
 
     return 0;
@@ -90,6 +97,6 @@ void Const::eventsLoop()
 int main(int argc, char *argv[])
 {
     Const c(argc, argv);
-    
+
     return 0;
 }

--- a/src/hal/icomp-example/C++_userspace_comp/constv2.cc
+++ b/src/hal/icomp-example/C++_userspace_comp/constv2.cc
@@ -1,9 +1,17 @@
+/**********************************************************************
+ * Demo of writing a SMP_SAFE userspace component in std C++
+ * 
+ * Based on the constant.icomp component
+ * 
+ * ArcEye 2015  <arceyeATmgwareDOTcoDOTuk>
+ * 
+***********************************************************************/ 
 
 #include <LCNC_Headers.h>
 
 using namespace std;
 
-struct __comp_state 
+struct __comp_state
 {
     float_pin_ptr out;
     float_pin_ptr value;
@@ -16,7 +24,7 @@ public:
     Const(int argc, char** argv);
     ~Const();
 
-private:    
+private:
     int connectPins();
     void eventsLoop();
 
@@ -29,19 +37,20 @@ private:
 Const::Const(int argc, char** argv)
 {
     int r;
-    
+
     strcpy(prefix, "constv2\0");  // used later in pins
     comp_id = hal_init("constv2");
-    
-    if(comp_id < 0) 
+
+    if(comp_id < 0)
         exit(-1);
-        
-    if((r = connectPins())) 
-        hal_exit(comp_id);    
+
+    if((r = connectPins()))
+        hal_exit(comp_id);
     else
         {
-	    hal_ready(comp_id);
-	    cout << "Component \""<< prefix << "\" registered and ready\n" << "comp_ID = " << comp_id << "\n" << endl;
+        hal_ready(comp_id);
+        cout << "Component \""<< prefix << "\" registered and ready\n"
+            << "comp_ID = " << comp_id << "\n" << endl;
         }
 
     eventsLoop();
@@ -61,15 +70,15 @@ int Const::connectPins()
 
     inst = (struct __comp_state*)hal_malloc(sz);
     memset(inst, 0, sz);
-    
+
     inst->out = halx_pin_float_newf(HAL_OUT, comp_id,"%s.out", prefix);
     if (float_pin_null(inst->out))
-	return _halerrno;
+        return _halerrno;
     set_float_pin(inst->out, 0.0);
-    
+
     inst->value = halx_pin_float_newf(HAL_IN, comp_id,"%s.value", prefix);
     if (float_pin_null(inst->value))
-	return _halerrno;
+        return _halerrno;
     set_float_pin(inst->value, 0.0);
 
     return 0;
@@ -78,26 +87,23 @@ int Const::connectPins()
 
 void Const::eventsLoop()
 {
-    hal_float_t tmp = 0, old_tmp = 0;
+hal_float_t tmp = 0, old_tmp = 0;
 
     while(1)
         {
-	    tmp = get_float_pin(inst->value);    
-	    if(tmp != old_tmp)
-		{
-		    cout << "\nvalue from out pin = " << tmp << endl;
-		    old_tmp = set_float_pin(inst->out, tmp);    
-		    cout << "\nvalue from set_float_pin = " << old_tmp << endl;
-		    old_tmp = tmp;
-		}
-        
-	    usleep(500000);
+        tmp = get_float_pin(inst->value);
+        // check to prevent constant pin updates with no change
+        if(tmp != old_tmp)
+            set_float_pin(inst->out, tmp);
+        // hand back to system for optimum period
+        // too low and nothing else will run properly
+        usleep(500000);
         }
 }
 
-extern "C" int main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
     Const c(argc, argv);
-    
+
     return 0;
 }


### PR DESCRIPTION
Remove debugging prints etc, use .cc extension etc

Signed-off-by: Mick <arceye@mgware.co.uk>