### PR TITLE
Correct error in timedelta(v2).icomp and scripts that use them

### DIFF
--- a/scripts/latency-plot
+++ b/scripts/latency-plot
@@ -1,4 +1,4 @@
-#!/usr/bin/wish8.5
+#!/usr/bin/wish8.6
 
 # Notes:
 # notusing y axis title because it coredumps with X BadMatch with wish8.5
@@ -192,7 +192,9 @@ proc start_hal_timedelta {} {
   hal loadrt timedelta names=base:time,servo:time
   hal addf  base:time base
   hal addf servo:time servo
-
+  hal setp base:time.count 2
+  hal setp servo:time.count 2
+  
   hal net  servo_max    servo:time.max
   hal net  servo_jitter servo:time.jitter
   hal net  servo_out    servo:time.out

--- a/scripts/latency-test
+++ b/scripts/latency-test
@@ -101,6 +101,9 @@ loadrt threads name1=fast period1=$BASE name2=slow period2=$SERVO
 loadrt timedelta count=2
 addf timedelta.0 fast
 addf timedelta.1 slow
+# if 2 components in use, let them know for average calcs
+setp timedelta.0.count 2
+setp timedelta.1.count 2
 start
 loadusr -Wn lat pyvcp lat.xml
 net sl timedelta.1.max => lat.sl

--- a/scripts/latency-test-atom-v2
+++ b/scripts/latency-test-atom-v2
@@ -56,14 +56,14 @@ SERVO_HUMAN=$(human_time $SERVO)
 if [ $BASE -eq 0 ]; then
 cat > lat.hal <<EOF
 loadrt threads name1=slow period1=$SERVO
-loadrt timedelta count=1
-addf timedelta.0 slow
+loadrt timedeltav2 count=1
+addf timedeltav2.0 slow
 start
 loadusr -Wn lat pyvcp lat.xml
-net sl timedelta.0.max => lat.sl
-net sj timedelta.0.jitter => lat.sj
-net st timedelta.0.out => lat.st
-net reset lat.reset => timedelta.0.reset
+net sl timedeltav2.0.max => lat.sl
+net sj timedeltav2.0.jitter => lat.sj
+net st timedeltav2.0.out => lat.st
+net reset lat.reset => timedeltav2.0.reset
 waitusr lat
 loadusr -w bash latexit.sh
 EOF
@@ -97,21 +97,21 @@ EOF
 else
 cat > lat.hal <<EOF
 loadrt threads name1=fast period1=$BASE cpu1=1 name2=slow period2=$SERVO cpu2=1
-loadrt timedelta count=2
-addf timedelta.0 fast
-addf timedelta.1 slow
+loadrt timedeltav2 count=2
+addf timedeltav2.0 fast
+addf timedeltav2.1 slow
 # if 2 components in use, let them know for average calcs
-setp timedelta.0.count 2
-setp timedelta.1.count 2
+setp timedeltav2.0.count 2
+setp timedeltav2.1.count 2
 start
 loadusr -Wn lat pyvcp lat.xml
-net sl timedelta.1.max => lat.sl
-net sj timedelta.1.jitter => lat.sj
-net st timedelta.1.out => lat.st
-net bl timedelta.0.max => lat.bl
-net bj timedelta.0.jitter => lat.bj
-net bt timedelta.0.out => lat.bt
-net reset lat.reset => timedelta.0.reset timedelta.1.reset
+net sl timedeltav2.1.max => lat.sl
+net sj timedeltav2.1.jitter => lat.sj
+net st timedeltav2.1.out => lat.st
+net bl timedeltav2.0.max => lat.bl
+net bj timedeltav2.0.jitter => lat.bj
+net bt timedeltav2.0.out => lat.bt
+net reset lat.reset => timedeltav2.0.reset timedeltav2.1.reset
 waitusr lat
 loadusr -w bash latexit.sh
 EOF

--- a/scripts/latency-test-legacy
+++ b/scripts/latency-test-legacy
@@ -116,6 +116,9 @@ loadrt threads name1=fast period1=$BASE name2=slow period2=$SERVO
 loadrt timedelta count=2
 addf timedelta.0 fast
 addf timedelta.1 slow
+# if 2 components in use, let them know for average calcs
+setp timedelta.0.count 2
+setp timedelta.1.count 2
 start
 loadusr -Wn lat pyvcp lat.xml
 net sl timedelta.1.max => lat.sl

--- a/scripts/latency-test-legacy-v2
+++ b/scripts/latency-test-legacy-v2
@@ -8,8 +8,8 @@ T=`mktemp -d`
 trap 'cd /; [ -d $T ] && rm -rf $T' SIGINT SIGTERM EXIT
 cd $T
 
-calc() { echo "scale=1; $1" | bc; }
-icalc() { echo "scale=0; ($1)*1" | bc | sed 's/\..*//'; }
+calc() { awk "BEGIN { print ($1); }" < /dev/null; }
+icalc() { awk "BEGIN { printf \"%.0f\n\", ($1); }" < /dev/null; }
 
 parse_time () {
     case $1 in
@@ -18,7 +18,7 @@ parse_time () {
     *us|*µs) icalc "1000*${1%us}" ;;
     *ms) icalc "1000*1000*${1%ms}" ;;
     *s)  icalc "1000*1000*1000*${1%s}" ;;
-    *)   if [ $1 -lt 1000 ]; then icalc "1000$*1"; else icalc "$1"; fi ;;
+    *)   if [ $1 -lt 1000 ]; then icalc "1000*$1"; else icalc "$1"; fi ;;
     esac
 }
 
@@ -31,21 +31,37 @@ human_time () {
     fi
 }
 
-BASE=$(parse_time 25us); SERVO=$(parse_time 1ms)
-case $# in
-0) ;;
-1) BASE=$(parse_time $1) ;;
-2) BASE=$(parse_time $1); SERVO=$(parse_time $2) ;;
-*)
-    echo "Usage: latency-test [base-period [servo-period]]"
-    echo "Default: latency-test 25us 1ms"
+usage () {
+    echo "Usage:"
+    echo "       latency-test-legacy [base-period [servo-period]]"
+    echo "   or:"
+    echo "       latency-test-legacy period -      # for single thread"
+    echo "   or:"
+    echo "       latency-test-legacy -h | --help   # (this text)"
+    echo ""
+    echo "Defaults:     base-period=${BASE}nS servo-period=${SERVO}nS"
+    echo "Equivalently: base-period=$(human_time $BASE) servo-period=$(human_time $SERVO)"
+    echo ""
     echo "Times may be specified with suffix \"s\", \"ms\", \"us\" \"µs\", or \"ns\""
     echo "Times without a suffix and less than 1000 are taken to be in us;"
     echo "other times without a suffix are taken to be in ns"
     echo ""
-    echo "The worst-case latency seen in any run of latency-test"
+    echo "The worst-case latency seen in any run of latency-test-legacy"
     echo "is written to the file ~/.latency"
     exit 1
+}
+
+BASE=$(parse_time 25us); SERVO=$(parse_time 1ms)
+
+case $1 in
+  -h|--help) usage;;
+esac
+
+case $# in
+0) ;;
+1) BASE=$(parse_time $1) ;;
+2) BASE=$(parse_time $1); SERVO=$(parse_time $2) ;;
+*) usage;;
 esac
 
 if [ "$BASE" -gt "$SERVO" ]; then TEMP=$BASE; BASE=$SERVO; SERVO=$TEMP; fi
@@ -56,21 +72,21 @@ SERVO_HUMAN=$(human_time $SERVO)
 if [ $BASE -eq 0 ]; then
 cat > lat.hal <<EOF
 loadrt threads name1=slow period1=$SERVO
-loadrt timedelta count=1
-addf timedelta.0 slow
+loadrt timedeltav2 count=1
+addf timedeltav2.0 slow
 start
 loadusr -Wn lat pyvcp lat.xml
-net sl timedelta.0.max => lat.sl
-net sj timedelta.0.jitter => lat.sj
-net st timedelta.0.out => lat.st
-net reset lat.reset => timedelta.0.reset
+net sl timedeltav2.0.max => lat.sl
+net sj timedeltav2.0.jitter => lat.sj
+net st timedeltav2.0.out => lat.st
+net reset lat.reset => timedeltav2.0.reset
 waitusr lat
 loadusr -w bash latexit.sh
 EOF
 
 cat > lat.xml <<EOF
 <pyvcp>
-<title title="Machinekit / HAL Latency Test"/>
+<title title="Machinekit / HAL Legacy Latency Test"/>
 <axisoptions/>
 <table>
 <tablerow/><tablespan columns="5"/><label wraplength="5i" justify="left">
@@ -96,29 +112,29 @@ EOF
 
 else
 cat > lat.hal <<EOF
-loadrt threads name1=fast period1=$BASE cpu1=1 name2=slow period2=$SERVO cpu2=1
-loadrt timedelta count=2
-addf timedelta.0 fast
-addf timedelta.1 slow
+loadrt threads name1=fast period1=$BASE name2=slow period2=$SERVO
+loadrt timedeltav2 count=2
+addf timedeltav2.0 fast
+addf timedeltav2.1 slow
 # if 2 components in use, let them know for average calcs
-setp timedelta.0.count 2
-setp timedelta.1.count 2
+setp timedeltav2.0.count 2
+setp timedeltav2.1.count 2
 start
 loadusr -Wn lat pyvcp lat.xml
-net sl timedelta.1.max => lat.sl
-net sj timedelta.1.jitter => lat.sj
-net st timedelta.1.out => lat.st
-net bl timedelta.0.max => lat.bl
-net bj timedelta.0.jitter => lat.bj
-net bt timedelta.0.out => lat.bt
-net reset lat.reset => timedelta.0.reset timedelta.1.reset
+net sl timedeltav2.1.max => lat.sl
+net sj timedeltav2.1.jitter => lat.sj
+net st timedeltav2.1.out => lat.st
+net bl timedeltav2.0.max => lat.bl
+net bj timedeltav2.0.jitter => lat.bj
+net bt timedeltav2.0.out => lat.bt
+net reset lat.reset => timedeltav2.0.reset timedeltav2.1.reset
 waitusr lat
 loadusr -w bash latexit.sh
 EOF
 
 cat > lat.xml <<EOF
 <pyvcp>
-<title title="Machinekit / HAL Latency Test"/>
+<title title="Machinekit / HAL Legacy Latency Test"/>
 <axisoptions/>
 <table>
 <tablerow/><tablespan columns="5"/><label wraplength="5i" justify="left">

--- a/scripts/latency-test-v2
+++ b/scripts/latency-test-v2
@@ -18,7 +18,7 @@ parse_time () {
     *us|*µs) icalc "1000*${1%us}" ;;
     *ms) icalc "1000*1000*${1%ms}" ;;
     *s)  icalc "1000*1000*1000*${1%s}" ;;
-    *)   if [ $1 -lt 1000 ]; then icalc "1000$*1"; else icalc "$1"; fi ;;
+    *)   if [ $1 -lt 1000 ]; then icalc "1000*$1"; else icalc "$1"; fi ;;
     esac
 }
 
@@ -31,14 +31,15 @@ human_time () {
     fi
 }
 
-BASE=$(parse_time 25us); SERVO=$(parse_time 1ms)
+#BASE=$(parse_time 25us); SERVO=$(parse_time 1ms)
+BASE=0; SERVO=$(parse_time 1ms)
 case $# in
 0) ;;
 1) BASE=$(parse_time $1) ;;
 2) BASE=$(parse_time $1); SERVO=$(parse_time $2) ;;
 *)
     echo "Usage: latency-test [base-period [servo-period]]"
-    echo "Default: latency-test 25us 1ms"
+    echo "Default: latency-test 1ms"
     echo "Times may be specified with suffix \"s\", \"ms\", \"us\" \"µs\", or \"ns\""
     echo "Times without a suffix and less than 1000 are taken to be in us;"
     echo "other times without a suffix are taken to be in ns"
@@ -56,14 +57,14 @@ SERVO_HUMAN=$(human_time $SERVO)
 if [ $BASE -eq 0 ]; then
 cat > lat.hal <<EOF
 loadrt threads name1=slow period1=$SERVO
-loadrt timedelta count=1
-addf timedelta.0 slow
+loadrt timedeltav2 count=1
+addf timedeltav2.0 slow
 start
 loadusr -Wn lat pyvcp lat.xml
-net sl timedelta.0.max => lat.sl
-net sj timedelta.0.jitter => lat.sj
-net st timedelta.0.out => lat.st
-net reset lat.reset => timedelta.0.reset
+net sl timedeltav2.0.max => lat.sl
+net sj timedeltav2.0.jitter => lat.sj
+net st timedeltav2.0.out => lat.st
+net reset lat.reset => timedeltav2.0.reset
 waitusr lat
 loadusr -w bash latexit.sh
 EOF
@@ -96,22 +97,22 @@ EOF
 
 else
 cat > lat.hal <<EOF
-loadrt threads name1=fast period1=$BASE cpu1=1 name2=slow period2=$SERVO cpu2=1
-loadrt timedelta count=2
-addf timedelta.0 fast
-addf timedelta.1 slow
+loadrt threads name1=fast period1=$BASE name2=slow period2=$SERVO
+loadrt timedeltav2 count=2
+addf timedeltav2.0 fast
+addf timedeltav2.1 slow
 # if 2 components in use, let them know for average calcs
-setp timedelta.0.count 2
-setp timedelta.1.count 2
+setp timedeltav2.0.count 2
+setp timedeltav2.1.count 2
 start
 loadusr -Wn lat pyvcp lat.xml
-net sl timedelta.1.max => lat.sl
-net sj timedelta.1.jitter => lat.sj
-net st timedelta.1.out => lat.st
-net bl timedelta.0.max => lat.bl
-net bj timedelta.0.jitter => lat.bj
-net bt timedelta.0.out => lat.bt
-net reset lat.reset => timedelta.0.reset timedelta.1.reset
+net sl timedeltav2.1.max => lat.sl
+net sj timedeltav2.1.jitter => lat.sj
+net st timedeltav2.1.out => lat.st
+net bl timedeltav2.0.max => lat.bl
+net bj timedeltav2.0.jitter => lat.bj
+net bt timedeltav2.0.out => lat.bt
+net reset lat.reset => timedeltav2.0.reset timedeltav2.1.reset
 waitusr lat
 loadusr -w bash latexit.sh
 EOF

--- a/src/hal/i_components/timedelta.icomp
+++ b/src/hal/i_components/timedelta.icomp
@@ -5,9 +5,14 @@ pin out s32 err=0;
 pin out s32 min_=0;
 pin out s32 max_=0;
 pin out s32 jitter=0;
-pin out float avg_err=0 """
-    still called avg_err for compatability, but only one instance so
-    err is just err """;
+pin out float avg_err=0;
+pin io s32 count = 1  """
+    This is the number of components in use.  It replaces the count
+    kernel parameter which was passed to the component in legacy
+    components.  If more than one in use, must setp this pin to that
+    number before initiating
+    See example in scripts/latency-test:104
+    """;
 pin in bit reset;
 
 function _ nofp;
@@ -42,7 +47,8 @@ hal_s64_t del = (now - last);
                 max_ = del;
             jitter = max(max_ - period, period - min_);
             }
-        avg_err = err;
+        count = (count + 1);
+        avg_err = err / count;
         }
 
     if(reset)

--- a/src/hal/i_components/timedeltav2.icomp
+++ b/src/hal/i_components/timedeltav2.icomp
@@ -5,9 +5,14 @@ pin_ptr out s32         err=0;
 pin_ptr out s32         min_=0;
 pin_ptr out s32         max_=0;
 pin_ptr out s32         jitter=0;
-pin_ptr out float       avg_err=0.0 """
-    still called avg_err for compatability, but only one instance so
-    err is just err """;
+pin_ptr out float       avg_err=0.0;
+pin_ptr io s32 count = 1  """
+    This is the number of components in use.  It replaces the count
+    kernel parameter which was passed to the component in legacy
+    components.  If more than one in use, must setp this pin to that
+    number before initiating
+    See example in scripts/latency-test:104
+    """;
 pin_ptr in bit          reset;
 
 function _ nofp;
@@ -44,7 +49,8 @@ hal_s64_t del = (now - last);
                 ss(max_,  del);
             ss(jitter, max(gs(max_) - period, period - gs(min_)));
             }
-        sf(avg_err, gs(err));
+        incs(count);
+        sf(avg_err, (gs(err) / gs(count)));
         }
 
     if(gb(reset))


### PR DESCRIPTION
Legacy components used the kernel parameter 'count' to determine
divisor for averaging operation.
This was overlooked in conversion.

As instances cannot easily determine how many other instances of
the same component are in use, a count pin has been added in order
that the calling script can inform all instances of this figure.

Signed-off-by: Mick <arceye@mgware.co.uk>