### PR TITLE
instcomp does not mangle component names with underscores

### DIFF
--- a/configs/attic/demo_mazak/demo_mazak.hal
+++ b/configs/attic/demo_mazak/demo_mazak.hal
@@ -92,7 +92,7 @@ loadrt mux4 count=1
 loadrt wcomp count=2
 loadrt scale count=3
 loadrt modmath mod_dir=2
-loadrt charge_pump
+newinst charge_pump charge-pump
 loadrt tristate_bit
 loadrt tristate_float count=3
 loadrt conv_s32_float
@@ -162,13 +162,13 @@ addf scale.1                        servo-thread
 addf mux4.0                         servo-thread
 addf wcomp.0                        servo-thread
 addf wcomp.1                        servo-thread
-addf tristate-bit.0                 servo-thread
+addf tristate_bit.0                 servo-thread
 
 # misc stuff (jogwheel scale, tool number display)
-addf tristate-float.0               servo-thread
-addf tristate-float.1               servo-thread
-addf tristate-float.2               servo-thread
-addf conv-s32-float.0               servo-thread
+addf tristate_float.0               servo-thread
+addf tristate_float.1               servo-thread
+addf tristate_float.2               servo-thread
+addf conv_s32_float.0               servo-thread
 
 # output drivers are loaded last
 addf motenc.3.dac-write             servo-thread
@@ -485,9 +485,9 @@ net magazine-rev-req-store mod-dir.1.down
 # set encoder latch enable TRUE so encoder count "wraps" during toolchanges
 # and resets under motion controller command for rigid tapping
 net sp-index-enable motenc.3.enc-03-index-enable
-net sp-index-enable tristate-bit.0.out
-setp tristate-bit.0.in 1
-net tool-change tristate-bit.0.enable
+net sp-index-enable tristate_bit.0.out
+setp tristate_bit.0.in 1
+net tool-change tristate_bit.0.enable
 net sp-index-enable motion.spindle-index-enable
 
 # jogwheel signals

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -2592,7 +2592,16 @@ FILE *Interp::find_ngc_file(setup_pointer settings,const char *basename, char *f
     return newFP;
 }
 
-static std::set<std::string> stringtable;
+
+struct StrcmpComparator
+{
+   bool operator()(const char * A, const char * B) const
+   {
+      return (strcmp(A, B) < 0) ;
+   }
+} ;
+
+static std::set<const char *, StrcmpComparator>  stringtable;
 
 const char *strstore(const char *s)
 {
@@ -2600,8 +2609,12 @@ const char *strstore(const char *s)
 
     if (s == NULL)
         throw invalid_argument("strstore(): NULL argument");
-    pair< set<string>::iterator, bool > pair = stringtable.insert(s);
-    return string(*pair.first).c_str();
+
+    std::set<const char *, StrcmpComparator>::iterator it = stringtable.find(s);
+    if (it == stringtable.end()) {
+	const char *p = strdup(s);
+	stringtable.insert(p);
+	return p;
+    }
+    return (*it);
 }
-
-


### PR DESCRIPTION
New version of instcomp does not mangle component names with underscores in them.

Check example configs comply

Edited last remaining config file to use component name underscore incorrectly

Many configs already named the component to have the underscore,
to side step the name mangling effect by comp and keep the loaded and the used
component name the same.

The rest were edited last year when we worked on it previously
